### PR TITLE
Update example for more recent webpack versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn add -D service-worker-loader
 ## [Usage](https://webpack.js.org/concepts/loaders)
 
 ```js
-import registerServiceWorker, { ServiceWorkerNoSupportError } from 'service-worker!./sw';
+import registerServiceWorker, { ServiceWorkerNoSupportError } from 'service-worker-loader!./sw';
 
 registerServiceWorker({ scope: '/' }).then(() => {
 	console.log('Success!');


### PR DESCRIPTION
Can't find package without `-loader` appended.