### PR TITLE
Sensible default - service worker name shouldn't change

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ registerServiceWorker({ scope: '/' }).then(() => {
 ### Options
 
 #### `filename`
-Defaults to `"[hash].[name].js"`. Specify the file name for generated Service Worker file
+Defaults to `"[name].js"`. Specify the file name for generated Service Worker file
 
 #### `publicPath`
 Defaults to `"/"`. Overrides default `publicPath`. 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function pitch(request) {
 
 	const cb = this.async();
 
-	const filename = loaderUtils.interpolateName(this, options.filename || '[hash].[name].js', {
+	const filename = loaderUtils.interpolateName(this, options.filename || '[name].js', {
 		context: options.context || this.options.context,
 		regExp:  options.regExp
 	});


### PR DESCRIPTION
Service workers check for updates at their original url. If the filename is hashed it will change when the file updates, and the service worker won't be able to update.

I can't think of any examples where it would be useful to have a hash in the filename. This PR suggests a more sensible default.

Depending on your point of view this may or may not be considered a breaking change.