### PR TITLE
Make compatible with webpack 4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ function pitch(request) {
 	const cb = this.async();
 
 	const filename = loaderUtils.interpolateName(this, options.filename || '[name].js', {
-		context: options.context || this.rootContext || this.context,
+		context: options.context || this.rootContext || this.options.context,
 		regExp:  options.regExp
 	});
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ function pitch(request) {
 	const cb = this.async();
 
 	const filename = loaderUtils.interpolateName(this, options.filename || '[name].js', {
-		context: options.context || this.options.context,
+		context: options.context || this.rootContext || this.context,
 		regExp:  options.regExp
 	});
 


### PR DESCRIPTION
With Webpack 4.0 causes error

```
Module build failed: TypeError: Cannot read property 'context' of undefined
```
Found same issue with worker-loader, and applied same fix

https://github.com/webpack-contrib/worker-loader/issues/125