### PR TITLE
Webpack 4 compatibility cont.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "webpack-loader"
   ],
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "loader-utils": "^1.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ function pitch(request) {
 	const cb = this.async();
 
 	const filename = loaderUtils.interpolateName(this, options.filename || '[name].js', {
-		context: options.context || this.rootContext || this.options.context,
+		context: options.context || this.rootContext || this.query.context || this.options.context,
 		regExp:  options.regExp
 	});
 
@@ -41,11 +41,13 @@ function pitch(request) {
 		namedChunkFilename: null
 	};
 
+	const query = this.query || this.options;
+
 	// TODO remove and triage eventual replacement via an option if needed
 	// doesn't work with webpack > v2.0.0
-	if (this.options && this.options.worker && this.options.worker.output) {
-		Object.keys(this.options.worker.output).forEach((name) => {
-			outputOptions[name] = this.options.worker.output[name];
+	if (query && query.worker && query.worker.output) {
+		Object.keys(query.worker.output).forEach((name) => {
+			outputOptions[name] = query.worker.output[name];
 		});
 	}
 
@@ -56,8 +58,8 @@ function pitch(request) {
 
 	// TODO remove and triage eventual replacement via an option if needed
 	// doesn't work with webpack > v2.0.0
-	if (this.options && this.options.worker && this.options.worker.plugins) {
-		this.options.worker.plugins.forEach(plugin =>
+	if (query && query.worker && query.worker.plugins) {
+		query.worker.plugins.forEach(plugin =>
 			compiler.apply(plugin)
 		);
 	}


### PR DESCRIPTION
replace this.options with this.query for webpack 4.0, still falls back to this.options.

also found an incompatibility with webpack hot module replacement trying to access window inside of the service worker.  Maybe we should make note of that in the readme? https://github.com/webpack/webpack/issues/6642

Also found deprecation warnings for Tapable but I'm not sure what dependency was causing it.

I apologize for the half-baked PR earlier

Edit: I think this will fix the peer dependency issues with David as well